### PR TITLE
Fixes Typo with SMTP (was SMPT)

### DIFF
--- a/src/routes/(app)/docs/going-to-production/+page.svelte
+++ b/src/routes/(app)/docs/going-to-production/+page.svelte
@@ -190,7 +190,7 @@
 
 <header class="highlighted-title bg-danger-alt m-t-0">
     <span class="label label-primary">highly recommended</span>
-    <HeadingLink title="Use SMPT mail server" tag="h5" />
+    <HeadingLink title="Use SMTP mail server" tag="h5" />
 </header>
 <p>
     By default, PocketBase uses the internal Unix <code>sendmail</code> command for sending emails.


### PR DESCRIPTION
Corrects SMPT to SMTP on "Use SMPT mail server".