### PR TITLE
change admin auth refresh path to auth-refresh

### DIFF
--- a/src/routes/(app)/docs/api-admins/AuthRefresh.svelte
+++ b/src/routes/(app)/docs/api-admins/AuthRefresh.svelte
@@ -91,7 +91,7 @@
 
     <div class="api-route alert alert-success">
         <strong class="label label-primary">POST</strong>
-        <div class="content">/api/admins/refresh</div>
+        <div class="content">/api/admins/auth-refresh</div>
         <small class="txt-hint auth-header">Requires <code>Authorization: TOKEN</code></small>
     </div>
 


### PR DESCRIPTION
In pocketbase documentation admin auth refresh endpoint `/api/admins/refresh` return 

```
  {
    "code": 404,
    "message": "Not Found.",
    "data": {}
  }
```
Changed that to `/api/admins/auth-refresh`. Now endpoint return correct response
```
{
  "admin": {
    "id": "3pvvja1r7rgd8ub",
    "created": "2022-12-06 04:19:04.747Z",
    "updated": "2022-12-06 04:19:04.747Z",
    "avatar": 0,
    "email": "test@example.com"
  },
  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzE1MTc5MDMsImlkIjoiM3B2dmphMXI3cmdkOHViIiwidHlwZSI6ImFkbWluIn0.U-TsLfZFP0aZud0pKYqxMtTLgh6hhwMFgzbsj6M_FGw"
}
```