### PR TITLE
Fixed onlyEmailDomains and exceptEmailDomains fields displaying wrong type

### DIFF
--- a/src/routes/(app)/docs/api-collections/Create.svelte
+++ b/src/routes/(app)/docs/api-collections/Create.svelte
@@ -450,7 +450,7 @@
                     </div>
                 </td>
                 <td>
-                    <span class="label">Boolean</span>
+                    <span class="label">Array</span>
                 </td>
                 <td>
                     Whether to allow sign-ups only with the email domains not listed in the specified list.
@@ -465,7 +465,7 @@
                     </div>
                 </td>
                 <td>
-                    <span class="label">Boolean</span>
+                    <span class="label">Array</span>
                 </td>
                 <td> Whether to allow sign-ups only with the email domains listed in the specified list. </td>
             </tr>

--- a/src/routes/(app)/docs/api-collections/List.svelte
+++ b/src/routes/(app)/docs/api-collections/List.svelte
@@ -66,8 +66,8 @@
                         "allowUsernameAuth": true,
                         "allowEmailAuth": true,
                         "requireEmail": true,
-                        "exceptEmailDomains": "",
-                        "onlyEmailDomains": "",
+                        "exceptEmailDomains": [],
+                        "onlyEmailDomains": [],
                         "minPasswordLength": 8
                       }
                     },

--- a/src/routes/(app)/docs/api-collections/Update.svelte
+++ b/src/routes/(app)/docs/api-collections/Update.svelte
@@ -425,7 +425,7 @@
                     </div>
                 </td>
                 <td>
-                    <span class="label">Boolean</span>
+                    <span class="label">Array</span>
                 </td>
                 <td>
                     Whether to allow sign-ups only with the email domains not listed in the specified list.
@@ -440,7 +440,7 @@
                     </div>
                 </td>
                 <td>
-                    <span class="label">Boolean</span>
+                    <span class="label">Array</span>
                 </td>
                 <td> Whether to allow sign-ups only with the email domains listed in the specified list. </td>
             </tr>


### PR DESCRIPTION

The API Returns `onlyEmailDomains` and `exceptEmailDomains` as type Array, not Boolean, which is what the website currently displays.

I also fixed the example responses. 