### PR TITLE
Mention 3 collection types instead of 2

### DIFF
--- a/src/routes/(app)/docs/collections/+page.svelte
+++ b/src/routes/(app)/docs/collections/+page.svelte
@@ -116,7 +116,7 @@
 <p>Here is what the collection panel looks like:</p>
 <img src="/images/screenshots/collection-panel.png" alt="Collection panel screenshot" class="screenshot" />
 <p>
-    Currently there are 2 collection types: <strong>Base</strong> and
+    Currently there are 3 collection types: <strong>Base</strong>, <strong>View</strong> and
     <strong>Auth</strong>.
 </p>
 


### PR DESCRIPTION
This page is a bit behind, as there are now 3 collection types: Base, View and Auth.