### PR TITLE
docs: add forcePathStyle property to S3 storage documentation

### DIFF
--- a/src/routes/(app)/docs/api-settings/List.svelte
+++ b/src/routes/(app)/docs/api-settings/List.svelte
@@ -35,7 +35,8 @@
                     "region": "",
                     "endpoint": "",
                     "accessKey": "",
-                    "secret": ""
+                    "secret": "",
+                    "forcePathStyle": false
                   },
                   "adminAuthToken": {
                     "secret": "******",

--- a/src/routes/(app)/docs/api-settings/Update.svelte
+++ b/src/routes/(app)/docs/api-settings/Update.svelte
@@ -35,7 +35,8 @@
                     "region": "",
                     "endpoint": "",
                     "accessKey": "",
-                    "secret": ""
+                    "secret": "",
+                    "forcePathStyle": ""
                   },
                   "adminAuthToken": {
                     "secret": "******",
@@ -515,7 +516,7 @@
             <tr>
                 <td class="min-width">
                     <div class="inline-flex flex-nowrap">
-                        <span class="txt">└─</span>
+                        <span class="txt">├─</span>
                         <span class="label label-success">Required</span>
                         <em>secret</em>
                     </div>
@@ -524,6 +525,27 @@
                     <span class="label">String</span>
                 </td>
                 <td>S3 storage secret (required if enabled).</td>
+            </tr>
+            <tr>
+                <td class="min-width">
+                    <div class="inline-flex flex-nowrap">
+                        <span class="txt">└─</span>
+                        <span class="label label-warning">Optional</span>
+                        <em>forcePathStyle</em>
+                    </div>
+                </td>
+                <td>
+                    <span class="label">Boolean</span>
+                </td>
+                <td>
+                    S3 storage forcePathStyle.
+                    <br />
+                    <small class="txt-hint"
+                        >Forces the request to use path-style addressing, eg.
+                        "https://s3.amazonaws.com/BUCKET/KEY" instead of the default
+                        "https://BUCKET.s3.amazonaws.com/KEY".
+                    </small>
+                </td>
             </tr>
 
             <!-- adminAuthToken -->


### PR DESCRIPTION
I am implementing currently an NextJS app with S3 access and I studied for this the API section (https://pocketbase.io/docs/api-settings/) in the documentation how I could set up an S3 storage via the REST API.

I found out that the UI checkbox `force path-style addressing` is missing in the REST API documentation but the property works when I send it over the API via your JS-SDK.
I was able to find evidence about the existence of this property [here](https://github.com/pocketbase/pocketbase/blob/master/models/settings/settings.go#L359).