### PR TITLE
Improve clarity about thumb sizes

### DIFF
--- a/src/routes/(app)/docs/files-handling/+page.svelte
+++ b/src/routes/(app)/docs/files-handling/+page.svelte
@@ -168,8 +168,9 @@
     </code>
 </p>
 <p>
-    If your file field has <strong>Thumb sizes</strong> option, you can get a thumb of an image file (jpg,
-    png) by just adding the <code>thumb</code> query parameter to the url like this:
+    If your file field has the <strong>Thumb sizes</strong> option, you can get a thumb of the image file
+    (currently limited to jpg, png, and partially gif – its first frame) by adding the <code>thumb</code>
+    query parameter to the url like this:
     <!-- prettier-ignore -->
     <code>
         http://127.0.0.1:8090/api/files/<span class="txt-danger">COLLECTION_ID_OR_NAME</span>/<span class="txt-info">RECORD_ID</span>/<span class="txt-success">FILENAME</span><strong>?thumb=100x300</strong>


### PR DESCRIPTION
I recently [asked a question](https://github.com/pocketbase/pocketbase/discussions/2647)  on the PocketBase discussions forum for some clarity on which files were acceptable for use with the _Thumb Sizes_ option. I referenced this part of the documentation and commented on its non-definitive explanation of exactly which image files were usable; so, I've added the key information, from that answer, into the documentation.

Also, feel free to let me know if I've made any mistakes in this process, as I've never committed to a project before.