### PR TITLE
Add example of using a multi-relation in API rules

### DIFF
--- a/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
+++ b/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
@@ -220,6 +220,14 @@
         />
     </li>
     <li class="m-b-sm">
+        Allow only registered users who are listed in an <em>allowed_users</em> multi-relation field value:
+        <CodeBlock
+            content={`
+                @request.auth.id != "" && allowed_users.id ?= @request.auth.id
+            `}
+        />
+    </li>
+    <li class="m-b-sm">
         Allow access by anyone and return only the records where the <em>title</em> field value starts with
         "Lorem" (eg. "Lorem ipsum"):
         <CodeBlock


### PR DESCRIPTION
I was expecting `allowed_users ?= @request.auth.id` to work based on how the multi-relation is presented in the admin UI, and had to dig up this discussion to figure out how the multi-relation is used: https://github.com/pocketbase/pocketbase/discussions/2157