### PR TITLE
Update template path in +page.svelte

### DIFF
--- a/src/routes/(app)/docs/go-rendering-templates/+page.svelte
+++ b/src/routes/(app)/docs/go-rendering-templates/+page.svelte
@@ -163,7 +163,7 @@
 
                     html, err := registry.LoadFiles(
                         "views/layout.html",
-                        "views/page.html",
+                        "views/hello.html",
                     ).Render(map[string]any{
                         "name": name,
                     })


### PR DESCRIPTION
For consistency in the new template example, update the template html file name to match the other references.