### PR TITLE
Fix typo in collections example

### DIFF
--- a/src/routes/(app)/docs/go-collections/+page.svelte
+++ b/src/routes/(app)/docs/go-collections/+page.svelte
@@ -77,7 +77,7 @@
                     },
                 },
             ),
-            Index: types.JsonArray[string]{
+            Indexes: types.JsonArray[string]{
                 "CREATE UNIQUE INDEX idx_user ON example (user)",
             },
         }


### PR DESCRIPTION
Typo in Go Collections creation example, `Index` should be [`Indexes`](https://github.com/peteretelej/pocketbase/blob/1679c88e6d215e6b3bdf08df91d6cceadc9725fb/models/collection.go#L30)