### PR TITLE
docker example as multi-stage build

### DIFF
--- a/src/routes/(app)/docs/going-to-production/+page.svelte
+++ b/src/routes/(app)/docs/going-to-production/+page.svelte
@@ -180,7 +180,7 @@
 <CodeBlock
     language="html"
     content={`
-        FROM alpine:latest FROM download
+        FROM alpine:latest AS download
 
         ARG PB_VERSION=` +
         (import.meta.env.PB_VERSION.startsWith("v")

--- a/src/routes/(app)/docs/going-to-production/+page.svelte
+++ b/src/routes/(app)/docs/going-to-production/+page.svelte
@@ -180,7 +180,7 @@
 <CodeBlock
     language="html"
     content={`
-        FROM alpine:latest
+        FROM alpine:latest FROM download
 
         ARG PB_VERSION=` +
         (import.meta.env.PB_VERSION.startsWith("v")
@@ -195,6 +195,10 @@
         # download and unzip PocketBase
         ADD https://github.com/pocketbase/pocketbase/releases/download/v\${PB_VERSION}/pocketbase_\${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
         RUN unzip /tmp/pb.zip -d /pb/
+
+        FROM scratch AS runner
+
+        COPY --from=download /pb/pocketbase /pb/
 
         # uncomment to copy the local pb_migrations dir into the image
         # COPY ./pb_migrations /pb/pb_migrations


### PR DESCRIPTION
The multi-stage build reduces the final image size by ~50%.

On my M1 MacBook (ARM64):

Image size from docs: 99.76MB
Image size multi-stage: 54.89MB