### PR TITLE
Improve docs for multitenancy apps use cases

### DIFF
--- a/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
+++ b/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
@@ -299,23 +299,23 @@
         // check if the user is a member of a team
         @collection.teamMembers:member.user ?= @request.auth.id &&
 
-        // check if the user is a member of this collection's team
-        @collection.teamMembers:member.team ?= team.id &&
+        // check if the user is a member of the current team
+        @collection.teamMembers:member.team ?= team &&
 
         // check if the user has the right permissions
         @collection.teamMembers:member.permissions:each ?= "edit_stuff"
     `}
 />
 <p>
-    This also works with <a href="/docs/working-with-relations#back-relations">back-relations</a>:
+    Aliases also work with <a href="/docs/working-with-relations#back-relations">back-relations</a>:
 </p>
 <CodeBlock
     content={`
-        // check if the user is a member of this collection's team
+        // check if the user is a member of the current team
         @request.auth.team_members_via_user:auth.team ?= team &&
 
         // check if the user has a specific role
-        @collection.teamMembers:auth.role ?= "moderator"
+        @request.auth.team_members_via_user:auth.role ?= "moderator"
     `}
 />
 <p>

--- a/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
+++ b/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
@@ -353,6 +353,22 @@
         />
     </li>
     <li class="m-b-sm">
+        Allow only registered users that are members of an <em>organization</em>:
+        <CodeBlock
+            content={`
+                @request.auth.id != "" && @request.auth.org_members_via_user.organization ?= organization
+            `}
+        />
+    </li>
+    <li class="m-b-sm">
+        Allow only <em>slugs</em> that are not already in use by other collections:
+        <CodeBlock
+            content={`
+                @collection.posts.slug ?!= slug && @collection.pages.slug ?!= slug
+            `}
+        />
+    </li>
+    <li class="m-b-sm">
         Allow access by anyone and return only the records where the <em>title</em> field value starts with
         "Lorem" (ex. "Lorem ipsum"):
         <CodeBlock

--- a/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
+++ b/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
@@ -164,8 +164,18 @@
             `}
         />
         <p>
+            In case you need to target relations where the associated relation field is not in the main
+            collection, you can use <a href="/docs/working-with-relations#back-relations">back-relations</a>:
+        </p>
+        <CodeBlock
+            content={`
+                comments_via_post.user ?= @request.auth.id
+            `}
+        />
+        <p>
             In case you want to join the same collection multiple times but based on different criteria, you
-            can define an alias by appending <code>:alias</code> suffix to the collection name.
+            can define an alias by appending an <code>:alias</code> suffix to the collection name (in this
+            example it was called <code>:auth</code>):
         </p>
         <CodeBlock
             content={`

--- a/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
+++ b/src/routes/(app)/docs/api-rules-and-filters/+page.svelte
@@ -277,6 +277,45 @@
     </small>
 </p>
 
+<HeadingLink title=":alias modifier" tag="h5" />
+
+<p>
+    The <code>:alias</code> field modifier allows you to define any suffix you want to a collection name, and could
+    be used in the case you want to join the same collection multiple times but based on different criteria. This
+    can be specially useful for apps that serves multiple tenants, organizations or teams. For example:
+</p>
+<CodeBlock
+    content={`
+        // check if the user is a member of a team
+        @collection.teamMembers:member.user ?= @request.auth.id &&
+
+        // check if the user is a member of this collection's team
+        @collection.teamMembers:member.team ?= team.id &&
+
+        // check if the user has the right permissions
+        @collection.teamMembers:member.permissions:each ?= "edit_stuff"
+    `}
+/>
+<p>
+    This also works with <a href="/docs/working-with-relations#back-relations">back-relations</a>:
+</p>
+<CodeBlock
+    content={`
+        // check if the user is a member of this collection's team
+        @request.auth.team_members_via_user:auth.team ?= team &&
+
+        // check if the user has a specific role
+        @collection.teamMembers:auth.role ?= "moderator"
+    `}
+/>
+<p>
+    <small class="txt-hint">
+        Note that <code class="txt-sm">:member</code> and <code class="txt-sm">:auth</code> are arbitrary aliases
+        used in this example to help indetify a collection related to an authenticated member. You can name your
+        aliases as you see fit for your use case.
+    </small>
+</p>
+
 <HeadingLink title="Examples" />
 <ul>
     <li class="m-b-sm">


### PR DESCRIPTION
Having organizations/teams/tenants is a quite common scenario, and PocketBase docs is a bit lacking in that regard, despite supporting those cases very well, so here are some changes:

- I couldn't find anything related to the `:alias` modifier apart from the brief mentioning that links to https://github.com/pocketbase/pocketbase/discussions/3805. That itself is very confusing because of the usage of `:auth` without disclaiming it's an arbitrary name. So I clarified that and added a dedicated section for it in the \"API rules and filters\" page based on https://github.com/pocketbase/pocketbase/discussions/4097.

- Back-relations are super useful in itself, and as mentioned on the discussion, you might not even need aliases if you use back-relations. Even so only aliases are mentioned in this page... so I added some references to back-relations, the first one coming before the `:alias` topic to avoid confusion.

- I also added two new examples that can be useful for these use cases. One for checking if the user is a member of an org/team using back-relations, and the other for checking if a value is already in use by other collection (that can also be useful for having unique usernames between the `users` and `organizations` collections).