### PR TITLE
Add missing paragraph to API records email change section

### DIFF
--- a/src/routes/(app)/docs/api-records/EmailChange.svelte
+++ b/src/routes/(app)/docs/api-records/EmailChange.svelte
@@ -15,6 +15,10 @@
 <Accordion single title="Email change">
     <div class="content m-b-sm">
         <p>Sends auth record email change request.</p>
+        <p>
+            On successful email change all previously issued auth tokens for the specific record will be
+            automatically invalidated.
+        </p>
     </div>
     <CodeTabs
         js={`


### PR DESCRIPTION
I added the same paragraph as successful _password reset_ about old tokens invalidation.