### PR TITLE
Update docs

### DIFF
--- a/src/routes/(app)/docs/api-collections/Create.svelte
+++ b/src/routes/(app)/docs/api-collections/Create.svelte
@@ -254,6 +254,10 @@
             // Unique collection name (used as a table name for the records table).
             name (required):  string
 
+            // Type of the collection.
+            // If not set, the collection type will be "base" by default.
+            type (optional): "base" | "view" | "auth"
+
             // List with the collection fields.
             // This field is optional and autopopulated for "view" collections based on the viewQuery.
             fields (required|optional): Array<Field>

--- a/src/routes/(app)/docs/api-records/Batch.svelte
+++ b/src/routes/(app)/docs/api-records/Batch.svelte
@@ -10,7 +10,7 @@
               [
                 {
                   "status": 200,
-                  "result": {
+                  "body": {
                     "collectionId": "a98f514eb05f454",
                     "collectionName": "demo",
                     "id": "ae40239d2bc4477",
@@ -22,7 +22,7 @@
                 },
                 {
                   "status": 200,
-                  "result": {
+                  "body": {
                     "collectionId": "a98f514eb05f454",
                     "collectionName": "demo",
                     "id": "31y1gc447bc9602",


### PR DESCRIPTION
Working with the HTTP API directly, I noticed two things in the API reference:

1. The property containing the actual data in the collection batch response is called `body` instead of `result`. This can also be seen in the [js-sdk](https://github.com/pocketbase/js-sdk/blob/2a7fcee2279b4cfe68edc695c4f367ca2bd101bf/src/services/BatchService.ts#L20).
2. The `type` property is missing in the collection create docs.