### PR TITLE
fix js sending http requests example

### DIFF
--- a/src/routes/(app)/docs/js-sending-http-requests/+page.svelte
+++ b/src/routes/(app)/docs/js-sending-http-requests/+page.svelte
@@ -42,7 +42,7 @@
 <CodeBlock
     language="javascript"
     content={`
-        onRecordBeforeCreateRequest((e) => {
+        onRecordCreateRequest((e) => {
             const isbn = e.record.get("isbn");
 
             // try to update with the published date from the openlibrary API


### PR DESCRIPTION
Changing `onRecordBeforeCreateRequest` deprecated hook with `onRecordCreateRequest`