### PR TITLE
Fix typos in docs

### DIFF
--- a/src/routes/(app)/docs/go-migrations/+page.svelte
+++ b/src/routes/(app)/docs/go-migrations/+page.svelte
@@ -359,8 +359,8 @@
                 )
 
                 // disable password auth and enable OTP only
-                collection.passwordAuth.enabled = false
-                collection.otp.enabled = true
+                collection.PasswordAuth.Enabled = false
+                collection.OTP.Enabled = true
 
                 collection.AddIndex("idx_clients_company", false, "company", "")
 


### PR DESCRIPTION
Small fix. Converts two lines in the docs ([go-migrations Example](https://pocketbase.io/docs/go-migrations/#creating-collection-programmatically)) from camelCase to PascalCase.

(PocketBase is amazing, by the way)