### PR TITLE
Update +page.svelte

### DIFF
--- a/src/routes/(app)/docs/go-overview/+page.svelte
+++ b/src/routes/(app)/docs/go-overview/+page.svelte
@@ -235,7 +235,7 @@
                         DBConnect: func(dbPath string) (*dbx.DB, error) {
                             const pragmas = "?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)&_pragma=journal_size_limit(200000000)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=cache_size(-16000)"
 
-                            return dbx.Open("sqlite3", dbPath+pragmas)
+                            return dbx.Open("sqlite3", "file:"+dbPath+pragmas)
                         },
                     })
 


### PR DESCRIPTION
`github.com/ncruces/go-sqlite3` need `file:` prefix

maybe need add wasm compile cache dir, the wasm compile cost 0.6s withoiut cache

```go
package main

import (
	"log"
	"math/bits"
	"path/filepath"

	"github.com/ncruces/go-sqlite3"
	_ "github.com/ncruces/go-sqlite3/driver"
	_ "github.com/ncruces/go-sqlite3/embed"
	"github.com/pocketbase/dbx"
	"github.com/pocketbase/pocketbase"
	"github.com/pocketbase/pocketbase/core"
	"github.com/tetratelabs/wazero"
	"github.com/tetratelabs/wazero/api"
)

func initSQLiteRC(dbPath string) {
	cfg := wazero.NewRuntimeConfig()
	if bits.UintSize < 64 {
		cfg = cfg.WithMemoryLimitPages(512) // 32MB
	} else {
		cfg = cfg.WithMemoryLimitPages(4096) // 256MB
	}
	cfg = cfg.WithCoreFeatures(api.CoreFeaturesV2)

	cacheDir := filepath.Join(dbPath, "../", core.LocalAutocertCacheDirName)
	cache, _ := wazero.NewCompilationCacheWithDir(cacheDir)
	cfg = cfg.WithCompilationCache(cache)

	sqlite3.RuntimeConfig = cfg
}

func main() {
	app := pocketbase.NewWithConfig(pocketbase.Config{
		DBConnect: func(dbPath string) (*dbx.DB, error) {
			if sqlite3.RuntimeConfig == nil {
				initSQLiteRC(dbPath)
			}
			const pragmas = "?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)&_pragma=journal_size_limit(200000000)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=cache_size(-16000)"

			return dbx.Open("sqlite3", "file:"+dbPath+pragmas)
		},
	})

	// custom hooks and plugins...

	if err := app.Start(); err != nil {
		log.Fatal(err)
	}

}

```