### PR TITLE
Update +page.svelte to add HAProxy configuration

### DIFF
--- a/src/routes/(app)/docs/going-to-production/+page.svelte
+++ b/src/routes/(app)/docs/going-to-production/+page.svelte
@@ -135,7 +135,7 @@
 <p>
     If you plan hosting multiple applications on a single server or need finer network controls, you can
     always put PocketBase behind a reverse proxy such as
-    <em>NGINX</em>, <em>Apache</em>, <em>Caddy</em>, etc.
+    <em>NGINX</em>, <em>Apache</em>, <em>Caddy</em>, <em>HAProxy</em>, etc.
     <br />
     <em>
         Just note that when using a reverse proxy you may need to setup the "User IP proxy headers" in the
@@ -189,6 +189,21 @@
             }
         }
     }
+    `}
+/>
+<p>
+    And a <em>HAProxy</em> configuration is:
+</p>
+<CodeBlock
+    language="html"
+    content={`
+    frontend example.com
+      bind *:80
+      option forwardfor
+      default_backend example.com_bck
+    
+    backend example.com_bck
+      server srv1 127.0.0.1:8090
     `}
 />
 <HeadingLink title="Using Docker" tag="h5" />


### PR DESCRIPTION
HAProxy is a reverse proxy as popular as nginx, sometimes even more. This change adds respective HAProxy configuration to the docs, to show how to configure it.