### PR TITLE
fix: typo in Introduction > Collections > Fields > Accordion > RelationField

### DIFF
--- a/src/routes/(app)/docs/collections/+page.svelte
+++ b/src/routes/(app)/docs/collections/+page.svelte
@@ -362,7 +362,7 @@
                 For <strong>single</strong> <code>relation</code>
                 <em>(the <code>MaxSelect</code> option is {`<=`} 1)</em>
                 the field value is a string:
-                <code>""</code>, <code>"RECOD_ID"</code>.
+                <code>""</code>, <code>"RECORD_ID"</code>.
             </p>
             <p>
                 For <strong>multiple</strong> <code>relation</code>


### PR DESCRIPTION
I found this typo while reading the docs and fixed it.

https://pocketbase.io/docs/collections/#relationfield