### PR TITLE
adds email_verified notice in oauth2 docs

### DIFF
--- a/src/routes/(app)/docs/authentication/OAuth2.svelte
+++ b/src/routes/(app)/docs/authentication/OAuth2.svelte
@@ -37,6 +37,19 @@
     </div>
 </div>
 
+<div class="alert alert-warning m-b-sm">
+  <div class="icon">
+    <i class="ri-error-warning-line" />
+  </div>
+  <div class="content">
+    <p>
+      Keep in mind that the <code>email_verified</code> field in the <strong>Userinfo</strong> response should
+      be truthy. Otherwise, PocketBase will treat the email as unverified  and the <code>email</code> field will
+      remain empty in the <code>auth</code> table.
+    </p>
+  </div>
+</div>
+
 <div class="tabs">
     <div class="tabs-header compact left">
         <button


### PR DESCRIPTION
Adds a notice field to keep in mind that `email_verified` needs to be set to `true` on the side of the OAuth2 Provider in order for `email` to work.