### PR TITLE
Specify User will be verified if not already on password reset confirmation

### DIFF
--- a/src/routes/(app)/docs/api-records/PasswordReset.svelte
+++ b/src/routes/(app)/docs/api-records/PasswordReset.svelte
@@ -35,6 +35,7 @@
             // ---
 
             // note: after this call all previously issued auth tokens are invalidated
+            // and the user will be marked as verified if not already
             await pb.collection('users').confirmPasswordReset(
                 'RESET_TOKEN',
                 'NEW_PASSWORD',
@@ -55,6 +56,7 @@
             // ---
 
             // note: after this call all previously issued auth tokens are invalidated
+            // and the user will be marked as verified if not already
             await pb.collection('users').confirmPasswordReset(
               'RESET_TOKEN',
               'NEW_PASSWORD',


### PR DESCRIPTION
If not verifier already, a User will be set as verified when a `/api/collections/collectionIdOrName/confirm-password-reset` is successfully processed.

This is specified here https://github.com/pocketbase/pocketbase/issues/4210#issuecomment-1903597954 and I could test it.